### PR TITLE
fix: add default values for capabilities

### DIFF
--- a/src/lib/ZebAgent.ts
+++ b/src/lib/ZebAgent.ts
@@ -334,14 +334,14 @@ export default class ZebAgent {
       initiatedAt: options.startedAt,
       startedAt: options.startedAt,
       desiredCapabilities: {
-        browserName: options.browserCapabilities.browser.name,
-        browserVersion: options.browserCapabilities.browser.version,
-        platformName: options.browserCapabilities.os.name,
+        browserName: options.browserCapabilities.browser.name || 'n/a',
+        browserVersion: options.browserCapabilities.browser.version || 'n/a',
+        platformName: options.browserCapabilities.os.name || 'n/a',
       },
       capabilities: {
-        browserName: options.browserCapabilities.browser.name,
-        browserVersion: options.browserCapabilities.browser.version,
-        platformName: options.browserCapabilities.os.name,
+        browserName: options.browserCapabilities.browser.name || 'n/a',
+        browserVersion: options.browserCapabilities.browser.version || 'n/a',
+        platformName: options.browserCapabilities.os.name || 'n/a',
       },
       testIds: [],
     };


### PR DESCRIPTION
issue #22 was because of `projects` settings weren't set in `playwright.config.ts` and method `suite.project()` returned `undefined`.
Right now if `suite.project()` return `undefined` capabilities set `n/a`.
P.S. may be need to describe this in documentation?
<img width="363" alt="Screenshot 2022-01-17 at 15 41 00" src="https://user-images.githubusercontent.com/55133404/149772014-23f8ce47-908e-48b7-94cf-8
<img width="377" alt="Screenshot 2022-01-17 at 15 48 09" src="https://user-images.githubusercontent.com/55133404/149772087-1bf31ff9-f523-4347-8e46-bc74aff9f78f.png">
39505670470.png">
<img width="1135" alt="Screenshot 2022-01-17 at 15 48 26" src="https://user-images.githubusercontent.com/55133404/149772097-d219eae7-b4db-431d-8f59-02647cad7205.png">


